### PR TITLE
feat: added "en" default language

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Locales implemented:
 - `bs`
 - `da`
 - `de`
+- `en`
 - `es`
 - `fr`
 - `he`

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as ar from './locales/ar';
 import * as bs from './locales/bs';
 import * as da from './locales/da';
 import * as de from './locales/de';
+import * as en from './locales/en';
 import * as es from './locales/es';
 import * as fr from './locales/fr';
 import * as he from './locales/he';
@@ -29,6 +30,7 @@ export {
   bs,
   da,
   de,
+  en,
   es,
   fr,
   he,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,64 @@
+/*eslint-disable no-template-curly-in-string*/
+import { printValue, LocaleObject } from 'yup';
+
+export const mixed: LocaleObject['mixed'] = {
+  default: '${path} is invalid',
+  required: '${path} is a required field',
+  defined: '${path} must be defined',
+  notNull: '${path} cannot be null',
+  oneOf: '${path} must be one of the following values: ${values}',
+  notOneOf: '${path} must not be one of the following values: ${values}',
+  notType: ({ path, type, value, originalValue }) => {
+    const isCast = originalValue != null && originalValue !== value;
+    let msg =
+      `${path} must be a \`${type}\` type, ` +
+      `but the final value was: \`${printValue(value, true)}\`` +
+      (isCast
+        ? ` (cast from the value \`${printValue(originalValue, true)}\`).`
+        : '.');
+
+    if (value === null) {
+      msg +=
+        `\n If "null" is intended as an empty value be sure to mark the schema as` +
+        ' `.nullable()`';
+    }
+
+    return msg;
+  },
+};
+export const string: LocaleObject['string'] = {
+  length: '${path} must be exactly ${length} characters',
+  min: '${path} must be at least ${min} characters',
+  max: '${path} must be at most ${max} characters',
+  matches: '${path} must match the following: "${regex}"',
+  email: '${path} must be a valid email',
+  url: '${path} must be a valid URL',
+  uuid: '${path} must be a valid UUID',
+  trim: '${path} must be a trimmed string',
+  lowercase: '${path} must be a lowercase string',
+  uppercase: '${path} must be a upper case string',
+};
+export const number: LocaleObject['number'] = {
+  min: '${path} must be greater than or equal to ${min}',
+  max: '${path} must be less than or equal to ${max}',
+  lessThan: '${path} must be less than ${less}',
+  moreThan: '${path} must be greater than ${more}',
+  positive: '${path} must be a positive number',
+  negative: '${path} must be a negative number',
+  integer: '${path} must be an integer',
+};
+export const date: LocaleObject['date'] = {
+  min: '${path} field must be later than ${min}',
+  max: '${path} field must be at earlier than ${max}',
+};
+export const object: LocaleObject['object'] = {
+  noUnknown: '${path} field has unspecified keys: ${unknown}',
+};
+export const array: LocaleObject['array'] = {
+  min: '${path} field must have at least ${min} items',
+  max: '${path} field must have less than or equal to ${max} items',
+  length: '${path} must have ${length} items',
+};
+export const boolean: LocaleObject['boolean'] = {
+  isValue: '${path} field must be ${value}',
+};


### PR DESCRIPTION
When you want to switch back to the default English language in yup by using `setLocale`, the `defaultLocale` object because of shallow copy will be same as the changed language. Therefore, there can be problems when switching back to English.

So we can fix this with deep copy like this:
```js
import { defaultLocale } from "yup";
const defaultLocaleClone = JSON.parse(JSON.stringify(defaultLocale));
```
But maybe importing default language is will be better and clearly solution like this:

```js
import { de ,en } from "yup-locales";
```