### PR TITLE
Add SPDX License Identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "yup-locales",
   "version": "0.0.0-development",
   "main": "dist/index.js",
+  "license": "MIT",
   "module": "dist/yup-locales.esm.js",
   "typings": "dist/index.d.ts",
   "keywords": [


### PR DESCRIPTION
Add license identifier according to [npm docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license).

This change helps tools like Black Duck to properly detect the license for this project.