### PR TITLE
fix: remove incorrect spaces from translations of the word email

### DIFF
--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -34,7 +34,7 @@ export const string: LocaleObject['string'] = {
   min: '${path} musí být alespoň ${min} znaky',
   max: '${path} musí být nejvýše ${max} znaky',
   matches: '${path} musí odpovídat následujícím: „${regex}“',
-  email: '${path} Musí to být platný e -mail',
+  email: '${path} Musí to být platný e-mail',
   url: '${path} musí být platná adresa URL',
   uuid: '${path} musí být platný uuid',
   trim: '${path} musí být oříznutá řetězec',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -34,7 +34,7 @@ export const string: LocaleObject['string'] = {
   min: '${path} skal være mindst ${min} tegn',
   max: '${path} skal højst være ${max} tegn',
   matches: '${path} skal matche følgende: "${regex}"',
-  email: '${path} skal være en gyldig e -mail',
+  email: '${path} skal være en gyldig e-mail',
   url: '${path} skal være en gyldig URL',
   uuid: '${path} skal være en gyldig UUID',
   trim: '${path} skal være en trimmet streng',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -34,7 +34,7 @@ export const string: LocaleObject['string'] = {
   min: '${path} muss mindestens ${min} Zeichen lang sein',
   max: '${path} darf höchstens ${max} Zeichen lang sein',
   matches: '${path} muss folgendes Muster haben: "${regex}"',
-  email: '${path} muss eine gültige E -Mail sein',
+  email: '${path} muss eine gültige E-Mail-Adresse sein',
   url: '${path} muss eine gültige URL sein',
   uuid: '${path} muss eine gültige UUID sein',
   trim: '${path} muss eine Zeichenfolge ohne Leerzeichen sein',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -34,7 +34,7 @@ export const string: LocaleObject['string'] = {
   min: '${path} deve essere almeno ${min} caratteri',
   max: '${path} deve essere al massimo ${max} caratteri',
   matches: '${path} deve abbinare quanto segue: "${regex}"',
-  email: "${path} deve essere un'e -mail valida",
+  email: "${path} deve essere un'e-mail valida",
   url: '${path} deve essere un URL valido',
   uuid: '${path} deve essere un uuid valido',
   trim: '${path} deve essere una stringa tagliata',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -34,7 +34,7 @@ export const string: LocaleObject['string'] = {
   min: '${path} musi być co najmniej ${min} znaki',
   max: '${path} musi być co najwyżej ${max} znaki',
   matches: '${path} musi dopasować następujące czynności: „${regex}”',
-  email: '${path} musi być ważnym e -mailem',
+  email: '${path} musi być ważnym e-mailem',
   url: '${path} musi być ważnym adresem URL',
   uuid: '${path} musi być ważnym UUID',
   trim: '${path} musi być przyciętym ciągiem',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -34,7 +34,7 @@ export const string: LocaleObject['string'] = {
   min: '${path} musia byť aspoň ${min} znaky',
   max: '${path} musia byť nanajvýš ${max} znaky',
   matches: '${path} sa musí zhodovať s nasledujúcimi: „${regex}“',
-  email: '${path} musí byť platný e -mail',
+  email: '${path} musí byť platný e-mail',
   url: '${path} musí byť platná adresa URL',
   uuid: '${path} musí byť platný uuid',
   trim: '${path} musí byť orezaný reťazec',


### PR DESCRIPTION
I found some wrong spaces within the German word for email. It is usually written like "E-Mail". Google Translate gave me the more precise word "E-Mail-Adresse" that I (as a native German) would agree to sound more correct in an error message.

I searched the project for more "e -mail" and counter checked with Google Translate. I'm very confident, that this space was also incorrect there.